### PR TITLE
Update definitions to allow booleans in the options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,9 +6,9 @@
 import { Middleware } from 'koa';
 
 declare function requestId(options?: {
-  expose?: string;
-  header?: string;
-  query?: string;
+  expose?: string | false;
+  header?: string | false;
+  query?: string | false;
 }): Middleware;
 
 export = requestId;


### PR DESCRIPTION
Options can also be booleans, and even though `true` will goof up the module, `false` does change the way this module works.