### PR TITLE
add node 12 to test versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
   - 8
   - 10
   - 11
+  - 12
 
 script:
   - yarn lint


### PR DESCRIPTION
Node 12 is the current LTS version so it seems fitting to be running tests against it, this PR adds version 12 to the travis config.