### PR TITLE
Remove Node 11 from Travis config, and add Node 13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: node_js
 node_js:
   - 8
   - 10
-  - 11
   - 12
+  - 13
 
 script:
   - yarn lint


### PR DESCRIPTION
Node 11 has [reached end-of-life](https://en.wikipedia.org/wiki/Node.js#Releases), so it's removed from the versions tested in CI.
Instead, Node 13 is introduced as the current release at the time of writing.

This change was originally proposed in [PR #22](https://github.com/uphold/koa-requestid/pull/22#issuecomment-568305584).